### PR TITLE
Add optional bloom-filter feature for selector matching optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ edition = "2018"
 [lib]
 name = "kuchikiki"
 
+[features]
+# Enable bloom filter optimization for faster selector matching.
+# Recommended for applications doing heavy selector matching across many elements.
+bloom-filter = []
+
 [dependencies]
 cssparser = "0.35.0"
 html5ever = "0.35.0"

--- a/examples/find_matches.rs
+++ b/examples/find_matches.rs
@@ -41,6 +41,6 @@ fn main() {
         //
         //  "Hello, world!"
         //  "I love HTML"
-        println!("{:?}", text);
+        println!("{text:?}");
     }
 }

--- a/examples/stack-overflow.rs
+++ b/examples/stack-overflow.rs
@@ -9,7 +9,7 @@ fn main() {
             node = parent;
         }
 
-        println!("Trying to drop {} nodes...", depth);
+        println!("Trying to drop {depth} nodes...");
         // Without an explicit `impl Drop for Node`,
         // depth = 20_000 causes "thread '<main>' has overflowed its stack"
         // on my machine (Linux x86_64).

--- a/src/select.rs
+++ b/src/select.rs
@@ -431,9 +431,35 @@ impl selectors::Element for NodeDataRef<ElementData> {
     }
 
     #[inline]
-    fn add_element_unique_hashes(&self, _filter: &mut selectors::bloom::BloomFilter) -> bool {
-        // No bloom filter optimization
-        false
+    fn add_element_unique_hashes(&self, filter: &mut selectors::bloom::BloomFilter) -> bool {
+        #[cfg(feature = "bloom-filter")]
+        {
+            // Add tag name hash (always present)
+            filter.insert_hash(self.name.local.precomputed_hash());
+
+            // Add ID hash if present
+            if let Some(id) = self.attributes.borrow().get(local_name!("id")) {
+                filter.insert_hash(LocalName::from(id).precomputed_hash());
+            }
+
+            // Add class hashes
+            if let Some(classes) = self.attributes.borrow().get(local_name!("class")) {
+                for class in classes.split(SELECTOR_WHITESPACE) {
+                    if !class.is_empty() {
+                        filter.insert_hash(LocalName::from(class).precomputed_hash());
+                    }
+                }
+            }
+
+            // We always add at least the tag name
+            true
+        }
+
+        #[cfg(not(feature = "bloom-filter"))]
+        {
+            let _ = filter; // Silence unused warning
+            false
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements optional bloom filter support for faster CSS selector matching, addressing #3.

## Changes

- Added `bloom-filter` cargo feature flag (non-default)
- Implemented `add_element_unique_hashes()` method in `Element` trait implementation
- Fixed clippy warnings in examples for uninlined format args

## Implementation Details

The bloom filter implementation uses conditional compilation:

**When `bloom-filter` feature is enabled:**
- Populates the bloom filter with element identifiers (tag names, IDs, classes)
- Adds tag name hash (always present for elements)
- Adds ID hash if the `id` attribute exists
- Adds class hashes for each space-separated class value
- Returns `true` to indicate hashes were added

**When `bloom-filter` feature is disabled (default):**
- Returns `false` without performing any operations
- Zero performance overhead for users who don't need this optimization

## Usage

Enable the feature in `Cargo.toml`:

```toml
[dependencies]
kuchikiki = { version = "0.8", features = ["bloom-filter"] }
```

## Performance Impact

This feature provides performance optimization for applications doing heavy selector matching across many elements by enabling fast negative lookups. The bloom filter allows the selector engine to quickly reject elements that cannot possibly match, avoiding expensive selector evaluation.

## Testing

- All existing tests pass with and without the feature
- `cargo test` - passes (feature disabled)
- `cargo test --features bloom-filter` - passes (feature enabled)
- `cargo clippy --features bloom-filter` - no warnings
- Pre-commit hooks all pass

Closes #3