### PR TITLE
Remove bloom-filter feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,6 @@
 
 - **Minimize unsafe code**: Use `unsafe` only when necessary and document safety requirements
 - **Error handling**: Use `Result` types with descriptive errors
-- **Feature gates**: Use `#[cfg(feature = "...")]` for optional functionality (e.g., bloom-filter)
 - **Path parameters**: Use `<P: AsRef<Path>>` when functions accept paths
 - **Comments**: End comment sentences with periods for readability
 - **TODOs**: Format as `// TODO: {description}.` (sentence case, ends with period)
@@ -30,7 +29,6 @@
 ## Testing
 
 - Write unit tests in `#[cfg(test)]` modules
-- Test both with and without feature flags (e.g., `cargo test --features bloom-filter`)
 - Use `#[should_panic]` or `Result` types for error case testing
 
 ## Linting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,6 @@ cargo test
 
 # Run clippy
 cargo clippy
-
-# Run with bloom-filter feature
-cargo test --features bloom-filter
 ```
 
 ## Coding Standards
@@ -98,7 +95,6 @@ When adding new features:
 - Write unit tests for new functionality
 - Consider integration tests for complex features
 - Ensure tests pass with `cargo test`
-- Test with feature flags: `cargo test --features bloom-filter`
 - Use `#[should_panic]` or `Result` types for error case testing
 
 ## Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,6 @@ indexmap = "2.12.0"
 precomputed-hash = "0.1.1"
 
 [features]
-# Enable bloom filter optimization for faster selector matching.
-bloom-filter = []
-
 # Unsafe code policy:
 # - Default mode: Uses unsafe code for performance
 # - Safe mode: Build with --features safe to eliminate all unsafe blocks

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This fork maintains compatibility with current servo crates (html5ever, selector
 - 🔍 **Node inspection** - traverse ancestors, siblings, descendants
 - 📝 **Serialization** - convert trees back to HTML
 - 🛡️ **Optional safe mode** - build without unsafe code
-- ⚡ **Performance optimizations** - optional bloom filter for selectors
 
 ## Installation
 
@@ -84,15 +83,6 @@ cargo test --features safe
 ```
 
 **Note:** This only affects brik's code, not its dependencies.
-
-### Bloom Filter Optimization
-
-Enable bloom filter optimization for faster CSS selector matching on large documents (applies to IDs and classes):
-
-```toml
-[dependencies]
-brik = { version = "0.8", features = ["bloom-filter"] }
-```
 
 ## Documentation
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -446,34 +446,8 @@ impl selectors::Element for NodeDataRef<ElementData> {
 
     #[inline]
     fn add_element_unique_hashes(&self, filter: &mut selectors::bloom::BloomFilter) -> bool {
-        #[cfg(feature = "bloom-filter")]
-        {
-            // Add tag name hash (always present)
-            filter.insert_hash(self.name.local.precomputed_hash());
-
-            // Add ID hash if present
-            if let Some(id) = self.attributes.borrow().get(local_name!("id")) {
-                filter.insert_hash(LocalName::from(id).precomputed_hash());
-            }
-
-            // Add class hashes
-            if let Some(classes) = self.attributes.borrow().get(local_name!("class")) {
-                for class in classes.split(SELECTOR_WHITESPACE) {
-                    if !class.is_empty() {
-                        filter.insert_hash(LocalName::from(class).precomputed_hash());
-                    }
-                }
-            }
-
-            // We always add at least the tag name
-            true
-        }
-
-        #[cfg(not(feature = "bloom-filter"))]
-        {
-            let _ = filter; // Silence unused warning
-            false
-        }
+        let _ = filter; // Silence unused warning
+        false
     }
 }
 


### PR DESCRIPTION
## Summary

Removes the `bloom-filter` feature until it can be properly profiled to verify its performance benefits.

## Changes

- ❌ Removed `bloom-filter` feature from `Cargo.toml`
- 🔧 Simplified `add_element_unique_hashes` to always return `false`
- 📚 Removed bloom-filter documentation from README.md
- 📝 Removed bloom-filter testing examples from CONTRIBUTING.md and CLAUDE.md

## Rationale

The bloom-filter optimization was added without proper profiling to demonstrate actual performance improvements. Removing it until performance testing can be conducted:

1. Reduces code complexity
2. Eliminates an untested feature flag
3. Simplifies documentation and testing instructions
4. Can be re-introduced later with proper benchmarks

## Impact

- **Breaking change**: Users using `features = ["bloom-filter"]` will need to remove this feature flag
- No functional impact on default builds
- All tests pass

Closes #16