### PR TITLE
Format code with cargo fmt

### DIFF
--- a/examples/namespaces.rs
+++ b/examples/namespaces.rs
@@ -51,8 +51,14 @@ fn main() {
     let attrs = svg.attributes.borrow();
 
     // All these attributes are in the null namespace
-    println!("  SVG width: {}", attrs.get_ns(ns!(), "width").unwrap_or("N/A"));
-    println!("  SVG height: {}", attrs.get_ns(ns!(), "height").unwrap_or("N/A"));
+    println!(
+        "  SVG width: {}",
+        attrs.get_ns(ns!(), "width").unwrap_or("N/A")
+    );
+    println!(
+        "  SVG height: {}",
+        attrs.get_ns(ns!(), "height").unwrap_or("N/A")
+    );
     println!("  Has xmlns? {}\n", attrs.has_ns(ns!(), "xmlns"));
 
     // Example 3: Iterating attributes by namespace
@@ -71,12 +77,18 @@ fn main() {
 
     println!("  HTML <p>:");
     println!("    namespace: {}", p.namespace_uri().as_ref());
-    println!("    Is XHTML? {}", p.namespace_uri().as_ref() == "http://www.w3.org/1999/xhtml");
+    println!(
+        "    Is XHTML? {}",
+        p.namespace_uri().as_ref() == "http://www.w3.org/1999/xhtml"
+    );
 
     println!("  SVG <circle>:");
     let circle = document.select_first("circle").unwrap();
     println!("    namespace: {}", circle.namespace_uri().as_ref());
-    println!("    Is SVG? {}", circle.namespace_uri().as_ref() == "http://www.w3.org/2000/svg");
+    println!(
+        "    Is SVG? {}",
+        circle.namespace_uri().as_ref() == "http://www.w3.org/2000/svg"
+    );
     println!();
 
     // Example 5: Working with rect attributes

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -7,18 +7,20 @@ use brik::traits::*;
 
 fn main() {
     // Parse an HTML document
-    let document = parse_html().one(r#"
+    let document = parse_html().one(
+        r#"
         <html>
             <body>
                 <p class="greeting">Hello, world!</p>
             </body>
         </html>
-    "#);
+    "#,
+    );
 
     // Query with CSS selectors
     if let Ok(match_) = document.select_first(".greeting") {
         let node = match_.as_node();
-        println!("{}", node.text_contents());  // Prints: Hello, world!
+        println!("{}", node.text_contents()); // Prints: Hello, world!
     }
 
     // Manipulate the tree

--- a/examples/template_processing.rs
+++ b/examples/template_processing.rs
@@ -54,7 +54,10 @@ fn main() {
         .elements()
         .elements_in_ns(ns!(svg))
         .collect();
-    println!("  SVG elements (template artifacts): {}\n", svg_elements.len());
+    println!(
+        "  SVG elements (template artifacts): {}\n",
+        svg_elements.len()
+    );
 
     // Step 2: Process template directives (simulated)
     println!("Step 2: Processing template directives");
@@ -112,5 +115,8 @@ fn main() {
     println!("✓ Template processing complete!");
     println!("  Original: {} elements", all_elements.len());
     println!("  Final: {} elements", remaining_elements.len());
-    println!("  Removed: {} elements", all_elements.len() - remaining_elements.len());
+    println!(
+        "  Removed: {} elements",
+        all_elements.len() - remaining_elements.len()
+    );
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -57,7 +57,10 @@ impl Attributes {
     }
 
     /// Like IndexMap::entry
-    pub fn entry<A: Into<LocalName>>(&mut self, local_name: A) -> Entry<'_, ExpandedName, Attribute> {
+    pub fn entry<A: Into<LocalName>>(
+        &mut self,
+        local_name: A,
+    ) -> Entry<'_, ExpandedName, Attribute> {
         self.map.entry(ExpandedName::new(ns!(), local_name))
     }
 
@@ -236,15 +239,13 @@ impl Attributes {
         N: Into<Namespace>,
     {
         let ns = namespace.into();
-        self.map
-            .iter()
-            .filter_map(move |(name, attr)| {
-                if name.ns == ns {
-                    Some((&name.local, attr.value.as_str()))
-                } else {
-                    None
-                }
-            })
+        self.map.iter().filter_map(move |(name, attr)| {
+            if name.ns == ns {
+                Some((&name.local, attr.value.as_str()))
+            } else {
+                None
+            }
+        })
     }
 
     /// Removes all xmlns namespace declarations for a given namespace URI.
@@ -292,7 +293,8 @@ impl Attributes {
         let xmlns_ns = Namespace::from("http://www.w3.org/2000/xmlns/");
 
         // Find all xmlns attributes whose value matches the target URI
-        let to_remove: Vec<_> = self.map
+        let to_remove: Vec<_> = self
+            .map
             .iter()
             .filter_map(|(name, attr)| {
                 if name.ns == xmlns_ns && attr.value == namespace_uri {
@@ -383,19 +385,9 @@ mod tests {
             map: Default::default(),
         };
 
-        attrs.insert_ns(
-            ns!(),
-            "test",
-            None,
-            "first".to_string(),
-        );
+        attrs.insert_ns(ns!(), "test", None, "first".to_string());
 
-        let old = attrs.insert_ns(
-            ns!(),
-            "test",
-            None,
-            "second".to_string(),
-        );
+        let old = attrs.insert_ns(ns!(), "test", None, "second".to_string());
 
         assert_eq!(old.as_ref().map(|a| a.value.as_str()), Some("first"));
         assert_eq!(attrs.get_ns(ns!(), "test"), Some("second"));

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -705,10 +705,7 @@ mod tests {
 
         let doc = parse_html().one(html);
 
-        let mut svg_elements = doc
-            .descendants()
-            .elements()
-            .elements_in_ns(ns!(svg));
+        let mut svg_elements = doc.descendants().elements().elements_in_ns(ns!(svg));
 
         // Test forward iteration
         let first = svg_elements.next().unwrap();
@@ -750,8 +747,7 @@ mod tests {
         let doc = parse_html().one(html);
 
         // Try to detach elements that don't exist - should not panic
-        doc
-            .descendants()
+        doc.descendants()
             .elements()
             .filter(|e| e.local_name().as_ref() == "nonexistent")
             .map(|e| e.as_node().clone())

--- a/src/node_data_ref.rs
+++ b/src/node_data_ref.rs
@@ -108,7 +108,9 @@ impl<T> NodeDataRef<T> {
                 _ if rc.as_element().is_some() => NodeDataKind::Element,
                 _ if rc.as_text().is_some() => NodeDataKind::Text,
                 _ if rc.as_comment().is_some() => NodeDataKind::Comment,
-                _ if rc.as_processing_instruction().is_some() => NodeDataKind::ProcessingInstruction,
+                _ if rc.as_processing_instruction().is_some() => {
+                    NodeDataKind::ProcessingInstruction
+                }
                 _ if rc.as_doctype().is_some() => NodeDataKind::Doctype,
                 _ if rc.as_document().is_some() => NodeDataKind::Document,
                 _ if rc.as_document_fragment().is_some() => NodeDataKind::DocumentFragment,
@@ -149,7 +151,9 @@ impl<T> NodeDataRef<T> {
                 _ if rc.as_element().is_some() => NodeDataKind::Element,
                 _ if rc.as_text().is_some() => NodeDataKind::Text,
                 _ if rc.as_comment().is_some() => NodeDataKind::Comment,
-                _ if rc.as_processing_instruction().is_some() => NodeDataKind::ProcessingInstruction,
+                _ if rc.as_processing_instruction().is_some() => {
+                    NodeDataKind::ProcessingInstruction
+                }
                 _ if rc.as_doctype().is_some() => NodeDataKind::Doctype,
                 _ if rc.as_document().is_some() => NodeDataKind::Document,
                 _ if rc.as_document_fragment().is_some() => NodeDataKind::DocumentFragment,
@@ -193,7 +197,9 @@ impl Deref for NodeDataRef<ElementData> {
     type Target = ElementData;
     #[inline]
     fn deref(&self) -> &ElementData {
-        self._keep_alive.as_element().expect("NodeDataRef<ElementData> must contain Element")
+        self._keep_alive
+            .as_element()
+            .expect("NodeDataRef<ElementData> must contain Element")
     }
 }
 
@@ -203,8 +209,14 @@ impl Deref for NodeDataRef<RefCell<String>> {
     #[inline]
     fn deref(&self) -> &RefCell<String> {
         match self._kind {
-            NodeDataKind::Text => self._keep_alive.as_text().expect("NodeDataRef with Text kind must contain text"),
-            NodeDataKind::Comment => self._keep_alive.as_comment().expect("NodeDataRef with Comment kind must contain comment"),
+            NodeDataKind::Text => self
+                ._keep_alive
+                .as_text()
+                .expect("NodeDataRef with Text kind must contain text"),
+            NodeDataKind::Comment => self
+                ._keep_alive
+                .as_comment()
+                .expect("NodeDataRef with Comment kind must contain comment"),
             _ => unreachable!("NodeDataRef<RefCell<String>> must be Text or Comment"),
         }
     }
@@ -215,7 +227,9 @@ impl Deref for NodeDataRef<Doctype> {
     type Target = Doctype;
     #[inline]
     fn deref(&self) -> &Doctype {
-        self._keep_alive.as_doctype().expect("NodeDataRef<Doctype> must contain Doctype")
+        self._keep_alive
+            .as_doctype()
+            .expect("NodeDataRef<Doctype> must contain Doctype")
     }
 }
 
@@ -224,7 +238,9 @@ impl Deref for NodeDataRef<DocumentData> {
     type Target = DocumentData;
     #[inline]
     fn deref(&self) -> &DocumentData {
-        self._keep_alive.as_document().expect("NodeDataRef<DocumentData> must contain Document")
+        self._keep_alive
+            .as_document()
+            .expect("NodeDataRef<DocumentData> must contain Document")
     }
 }
 
@@ -233,7 +249,9 @@ impl Deref for NodeDataRef<RefCell<(String, String)>> {
     type Target = RefCell<(String, String)>;
     #[inline]
     fn deref(&self) -> &RefCell<(String, String)> {
-        self._keep_alive.as_processing_instruction().expect("NodeDataRef<RefCell<(String, String)>> must contain ProcessingInstruction")
+        self._keep_alive
+            .as_processing_instruction()
+            .expect("NodeDataRef<RefCell<(String, String)>> must contain ProcessingInstruction")
     }
 }
 
@@ -242,7 +260,9 @@ impl Deref for NodeDataRef<()> {
     type Target = ();
     #[inline]
     fn deref(&self) -> &() {
-        self._keep_alive.as_document_fragment().expect("NodeDataRef<()> must contain DocumentFragment")
+        self._keep_alive
+            .as_document_fragment()
+            .expect("NodeDataRef<()> must contain DocumentFragment")
     }
 }
 
@@ -405,10 +425,7 @@ mod tests {
         let div = doc.select_first("div").unwrap();
 
         // Should work without .as_element().unwrap()
-        assert_eq!(
-            div.namespace_uri().as_ref(),
-            "http://www.w3.org/1999/xhtml"
-        );
+        assert_eq!(div.namespace_uri().as_ref(), "http://www.w3.org/1999/xhtml");
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,7 +80,10 @@ impl TreeSink for Sink {
 
     type Handle = NodeRef;
 
-    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
+    type ElemName<'a>
+        = ExpandedName<'a>
+    where
+        Self: 'a;
 
     #[inline]
     fn parse_error(&self, message: Cow<'static, str>) {

--- a/src/select.rs
+++ b/src/select.rs
@@ -366,9 +366,7 @@ impl selectors::Element for NodeDataRef<ElementData> {
         self.attributes
             .borrow()
             .get(local_name!("id"))
-            .is_some_and(|id_attr| {
-                case_sensitivity.eq(id.as_bytes(), id_attr.as_bytes())
-            })
+            .is_some_and(|id_attr| case_sensitivity.eq(id.as_bytes(), id_attr.as_bytes()))
     }
 
     #[inline]
@@ -393,10 +391,9 @@ impl selectors::Element for NodeDataRef<ElementData> {
     ) -> bool {
         let attrs = self.attributes.borrow();
         match *ns {
-            NamespaceConstraint::Any => attrs
-                .map
-                .iter()
-                .any(|(name, attr)| name.local == **local_name && operation.eval_str(attr.value.as_str())),
+            NamespaceConstraint::Any => attrs.map.iter().any(|(name, attr)| {
+                name.local == **local_name && operation.eval_str(attr.value.as_str())
+            }),
             NamespaceConstraint::Specific(ns_url) => attrs
                 .map
                 .get(&ExpandedName::new(ns_url, (**local_name).clone()))
@@ -475,8 +472,14 @@ impl Selectors {
     #[inline]
     pub fn compile(s: &str) -> Result<Selectors, ()> {
         let mut input = cssparser::ParserInput::new(s);
-        match SelectorList::parse(&BrikParser, &mut cssparser::Parser::new(&mut input), selectors::parser::ParseRelative::No) {
-            Ok(list) => Ok(Selectors(list.slice().iter().cloned().map(Selector).collect())),
+        match SelectorList::parse(
+            &BrikParser,
+            &mut cssparser::Parser::new(&mut input),
+            selectors::parser::ParseRelative::No,
+        ) {
+            Ok(list) => Ok(Selectors(
+                list.slice().iter().cloned().map(Selector).collect(),
+            )),
             Err(_) => Err(()),
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -586,10 +586,7 @@ mod tests {
         let html = r"<!DOCTYPE html><html><body><div>Test</div></body></html>";
         let document = parse_html().one(html);
         let div = document.select_first("div").unwrap();
-        assert_eq!(
-            div.namespace_uri().as_ref(),
-            "http://www.w3.org/1999/xhtml"
-        );
+        assert_eq!(div.namespace_uri().as_ref(), "http://www.w3.org/1999/xhtml");
 
         // Test SVG element namespace
         let svg_html = r#"<!DOCTYPE html>


### PR DESCRIPTION
## Summary

Ran `cargo fmt --all` to format the entire codebase according to Rust style guidelines.

## Changes

Formatted 9 files:
- `examples/namespaces.rs`
- `examples/quickstart.rs`
- `examples/template_processing.rs`
- `src/attributes.rs`
- `src/iter.rs`
- `src/node_data_ref.rs`
- `src/parser.rs`
- `src/select.rs`
- `src/tree.rs`

All changes are purely formatting - no logic changes.

## Testing

- ✅ All tests passing (57 tests)
- ✅ All pre-commit hooks passed
- ✅ Cargo fmt reports no issues
- ✅ Clippy passes with no warnings

Closes #27