### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2025-10-24
+
 ### Added
 
 - Namespace support for XML and SVG documents behind `namespaces` feature flag (#15, #21, #23, #29)
@@ -53,5 +55,6 @@ See [docs/historical-changelog.md](docs/historical-changelog.md) for details.
 **Historical Note**: This project was originally created by Simon Sapin as `kuchiki`,
 maintained by Brave Browser as `kuchikiki`, and is now maintained as `brik`.
 
-[unreleased]: https://github.com/theroyalwhee0/brik/compare/v0.8.2...HEAD
+[unreleased]: https://github.com/theroyalwhee0/brik/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/theroyalwhee0/brik/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/theroyalwhee0/brik/releases/tag/v0.8.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,31 @@
 # Project Coding Standards
 
+## Workflow
+
+### Working with GitHub Issues
+
+- **ALWAYS use `focus-issue <number>` to start work on an issue** - this command:
+  - Fetches the issue details and saves them to `.focus/Task.md`
+  - Creates or switches to the appropriate issue branch
+  - Handles branch management and cleanup automatically
+  - Archives previous `.focus/` directories to keep workspace clean
+- **DO NOT manually**:
+  - Use `gh issue view` - the focus-issue command does this for you
+  - Create issue branches - the focus-issue command handles this
+  - Manually create `.focus/` directories - always use focus-issue
+
+**Example:**
+
+```bash
+# Start working on issue #41
+focus-issue 41
+
+# The command automatically:
+# - Fetches issue content to .focus/Task.md
+# - Creates/switches to branch 41-publish-v090
+# - Archives any previous .focus directory
+```
+
 ## Communication
 
 - **Time estimates**: Don't include time estimates unless explicitly requested

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "brik"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "cssparser",
  "html5ever",
@@ -311,9 +311,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brik"
-version = "0.8.2"
+version = "0.9.0"
 authors = [
   "Adam Mill <hismajesty@theroyalwhee.com>",
   "Brave Authors",


### PR DESCRIPTION
## Summary

Prepares the initial v0.9.0 release of brik, forked from kuchikiki 0.8.2.

## Changes

- Update version to 0.9.0 in `Cargo.toml`
- Update `CHANGELOG.md` with v0.9.0 release date (2025-10-24)
- Add version comparison links for v0.9.0
- Update `CLAUDE.md` with `focus-issue` workflow documentation
- Regenerate `Cargo.lock`

## Major Features in v0.9.0

### Added
- **Namespace support** for XML and SVG documents behind `namespaces` feature flag (#15, #21, #23, #29)
  - Namespace-aware attribute methods with prefix and URI handling
  - Namespace iterator and filtering capabilities
  - Namespace manipulation and batch removal operations
  - CSS selectors with namespace support (e.g., `svg|rect`, `*|div`)
  
- **Safe mode** feature flag to eliminate all unsafe code blocks (#17)
  - Default mode uses unsafe code for performance
  - Opt-in safe mode available
  
- **CI/CD workflow** with GitHub Actions (#14, #16, #18, #25)
  - Automated testing for both default and safe modes
  - Clippy linting and security audits
  - Code coverage enforcement
  
- **Comprehensive API documentation** with examples (#35, #39)
  - All public items documented
  - Panic and error documentation
  - Examples for namespace usage and template processing (#26)
  
- **Colocated tests** with implementation code (#20, #31)
  - Tests moved from separate files to inline modules
  - Improved discoverability and maintainability

### Changed
- Forked from `kuchikiki` 0.8.2 and rebranded to `brik` (2025-10-21)
- Renamed internal types from `Kuchiki*` to `Brik*` (#24, #25)
- Restructured codebase following one-pub-per-file convention (#30, #32)
- Updated dependencies (#1)

## Test Results

- ✅ All 245 unit tests pass
- ✅ All 22 doc tests pass  
- ✅ Code coverage: 94.95% line coverage
- ✅ All pre-commit hooks pass
- ✅ `cargo clippy` clean
- ✅ `cargo fmt` clean
- ✅ All examples build successfully

## Git Tag

Created and pushed tag: `v0.9.0`

## Next Steps

After merging:
1. Merge to main
2. Publish to crates.io with `cargo publish`
3. Create GitHub release from the v0.9.0 tag

Closes #41