### PR TITLE
Bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2025-10-24
+
+### Fixed
+
+- Remove future-looking documentation from SelectorContext (#43)
+- Remove uncertain "(if exists)" qualifier from documentation (#43)
+
+### Changed
+
+- Add namespace support to Features list in README (#43)
+- Update version references in README to match current release
+
 ## [0.9.0] - 2025-10-24
 
 ### Added
@@ -55,6 +67,7 @@ See [docs/historical-changelog.md](docs/historical-changelog.md) for details.
 **Historical Note**: This project was originally created by Simon Sapin as `kuchiki`,
 maintained by Brave Browser as `kuchikiki`, and is now maintained as `brik`.
 
-[unreleased]: https://github.com/theroyalwhee0/brik/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/theroyalwhee0/brik/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/theroyalwhee0/brik/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/theroyalwhee0/brik/compare/v0.8.2...v0.9.0
-[0.8.2]: https://github.com/theroyalwhee0/brik/releases/tag/v0.8.2
+[0.8.2]: https://github.com/brave/kuchikiki/releases/tag/v0.8.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "brik"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cssparser",
  "html5ever",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brik"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
   "Adam Mill <hismajesty@theroyalwhee.com>",
   "Brave Authors",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-brik = "0.9"
+brik = "0.9.1"
 ```
 
 ### Migrating from Kuchiki or Kuchikiki
@@ -41,7 +41,7 @@ This migration applies to both Kuchiki and Kuchikiki.
 
 ```toml
 [dependencies]
-brik = "0.9"  # Changed from "kuchiki" or "kuchikiki"
+brik = "0.9.1"  # Changed from "kuchiki" or "kuchikiki"
 ```
 
 Update your code:
@@ -73,7 +73,7 @@ By default, brik uses unsafe code for performance. To build without any unsafe b
 
 ```toml
 [dependencies]
-brik = { version = "0.9", features = ["safe"] }
+brik = { version = "0.9.1", features = ["safe"] }
 ```
 
 Or via command line:
@@ -91,7 +91,7 @@ XML/SVG namespace support is available via the `namespaces` feature:
 
 ```toml
 [dependencies]
-brik = { version = "0.9", features = ["namespaces"] }
+brik = { version = "0.9.1", features = ["namespaces"] }
 ```
 
 This enables:


### PR DESCRIPTION
## Summary

- Update version in Cargo.toml and Cargo.lock to 0.9.1
- Update all version references in README.md
- Add 0.9.1 section to CHANGELOG.md documenting documentation fixes from #43
- Fix CHANGELOG version links: 0.9.0 compares our v0.8.2 to v0.9.0, 0.8.2 links to kuchikiki upstream

Fixes #46